### PR TITLE
Fetch OpenAI models dynamically and improve generation feedback

### DIFF
--- a/app/services/models.py
+++ b/app/services/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import List
+
+import openai
+
+
+def fetch_available_models(api_key: str | None) -> List[str]:
+    """Return a sorted list of chat-capable OpenAI models.
+
+    Falls back to an empty list if no API key is provided or if the
+    request to the OpenAI API fails for any reason. Only models whose
+    identifiers start with ``gpt-`` are returned since the application
+    uses chat completion endpoints for generation.
+    """
+
+    if not api_key:
+        return []
+
+    openai.api_key = api_key
+
+    try:  # pragma: no cover - network interaction is not unit tested
+        response = openai.Model.list()
+    except Exception:  # noqa: BLE001 - propagate as graceful fallback
+        return []
+
+    candidates = []
+    for item in response.get("data", []):
+        model_id = item.get("id")
+        if isinstance(model_id, str) and model_id.startswith("gpt-"):
+            candidates.append(model_id)
+
+    # Remove duplicates while keeping the first occurrence order.
+    seen = set()
+    unique = [model for model in candidates if not (model in seen or seen.add(model))]
+    return sorted(unique)

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -55,8 +55,9 @@
             No OpenAI API key detected. Demo mode is enabled automatically. Visit the <a href="{{ url_for('main.settings') }}" class="alert-link">settings page</a> to add one for live generations.
           </div>
           {% endif %}
+          <div id="generation-status" class="alert alert-info mt-3 d-none" role="status"></div>
           <div class="d-grid mt-4">
-            <button class="btn btn-primary btn-lg" type="submit">Build my topic map</button>
+            <button class="btn btn-primary btn-lg" type="submit" id="generate-button">Make the subtopic map</button>
           </div>
         </form>
       </div>
@@ -111,6 +112,12 @@
 {% block scripts %}
 <script>
   const textarea = document.getElementById('topics');
+  const form = document.querySelector('form[action="{{ url_for('main.generate') }}"]');
+  const statusElement = document.getElementById('generation-status');
+  const modelSelect = document.getElementById('model');
+  const depthInput = document.getElementById('depth');
+  const temperatureInput = document.getElementById('temperature');
+  const demoModeCheckbox = document.getElementById('demo_mode');
   if (textarea) {
     const chips = document.querySelectorAll('.topic-chip');
     chips.forEach((chip) => {
@@ -125,6 +132,27 @@
         if (!segments.includes(value)) {
           textarea.value = `${existing}\n${value}`;
         }
+      });
+    });
+  }
+  if (form && statusElement) {
+    form.addEventListener('submit', () => {
+      const topics = textarea ? textarea.value.trim().split(/[\n,]/).map((item) => item.trim()).filter(Boolean) : [];
+      const selectedModel = modelSelect ? modelSelect.value : 'unknown model';
+      const depth = depthInput ? depthInput.value : 'N/A';
+      const temperature = temperatureInput ? temperatureInput.value : 'N/A';
+      const demoMode = demoModeCheckbox ? demoModeCheckbox.checked : false;
+      const summary = `Generating subtopic map with ${topics.length || 'no'} topic${topics.length === 1 ? '' : 's'} using ${selectedModel} at depth ${depth}.`;
+      statusElement.textContent = summary;
+      statusElement.classList.remove('d-none', 'alert-success', 'alert-danger');
+      statusElement.classList.add('alert-info');
+      console.log({
+        event: 'generate_subtopic_map',
+        topics,
+        model: selectedModel,
+        depth,
+        temperature,
+        demoMode,
       });
     });
   }


### PR DESCRIPTION
## Summary
- fetch chat-capable model identifiers from the OpenAI API when an API key is configured and surface them in the UI
- fall back to the first available model if the stored default is no longer present
- show an inline status alert and console log entry when a subtopic map generation is requested

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc7811b430832f9cad7d1046c981aa